### PR TITLE
Update flexible_freeze.py to not exit on table failure

### DIFF
--- a/scripts/flexible_freeze.py
+++ b/scripts/flexible_freeze.py
@@ -354,6 +354,7 @@ for db in dblist:
             _print(str(ex))
             if time.time() >= halt_time:
                 verbose_print("halted flexible_freeze due to enforced time limit")
+                sys.exit(1)
             else:
                 _print("VACUUMING %s failed." % table[0])
                 _print(str(ex))

--- a/scripts/flexible_freeze.py
+++ b/scripts/flexible_freeze.py
@@ -357,7 +357,6 @@ for db in dblist:
             else:
                 _print("VACUUMING %s failed." % table[0])
                 _print(str(ex))
-            sys.exit(1)
 
         time.sleep(args.pause_time)
 

--- a/scripts/flexible_freeze.py
+++ b/scripts/flexible_freeze.py
@@ -355,9 +355,6 @@ for db in dblist:
             if time.time() >= halt_time:
                 verbose_print("halted flexible_freeze due to enforced time limit")
                 sys.exit(1)
-            else:
-                _print("VACUUMING %s failed." % table[0])
-                _print(str(ex))
 
         time.sleep(args.pause_time)
 


### PR DESCRIPTION
```
DEBUG (2025-02-19 23:14:35 UTC): appended comment to sql: SET statement_timeout = 0 /* application:flexible_freeze,pganalyze:no-alert */
DEBUG (2025-02-19 23:14:35 UTC): appended comment to sql: VACUUM FREEZE ANALYZE "fivetran_test.actions_test" /* application:flexible_freeze,pganalyze:no-alert */
VACUUMing fivetran_test.actions_test failed.
relation "fivetran_test.actions_test" does not exist

VACUUMING f failed.
relation "fivetran_test.actions_test" does not exist
```